### PR TITLE
Fix configuration

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -53,6 +53,6 @@
   ],
   "requireConfig": "required",
   "schedule": [
-    "30 5 * * MON-FRI"
+    "* 5 * * MON-FRI"
   ]
 }


### PR DESCRIPTION
Renovate doesn't allow minute granularity:

```text
WARN: Found errors in inherited configuration.
{
  "errors": [
    {
      "topic": "Configuration Error",
      "message": "Invalid schedule: `Invalid schedule: \"30 5 * * MON-FRI\" has cron syntax, but doesn't have * as minutes`"
    }
  ]
}
```