### PR TITLE
Update Microsoft.DotNet.XliffTasks weekly

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -52,6 +52,11 @@
       "description": ["Disable major version updates for .NET"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchDepNames": ["Microsoft.DotNet.XliffTasks"],
+      "description": ["Only update Microsoft.DotNet.XliffTasks once a week"],
+      "schedule": ["* 5-21 * * MON"]
     }
   ],
   "requireConfig": "required",


### PR DESCRIPTION
Only update Microsoft.DotNet.XliffTasks weekly as it is built almost-daily due to it being part of the public .NET CI.
