### PR TITLE
Add cooldown for .NET updates

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -54,6 +54,11 @@
       "enabled": false
     },
     {
+      "extends": ["monorepo:dotnet"],
+      "description": ["Cooldown on .NET updates to maximize batching"],
+      "minimumReleaseAge": "1 day"
+    },
+    {
       "matchDepNames": ["Microsoft.DotNet.XliffTasks"],
       "description": ["Only update Microsoft.DotNet.XliffTasks once a week"],
       "schedule": ["* 5-21 * * MON"]


### PR DESCRIPTION
Wait 1 day before updating dependencies from .NET to avoid competing with other automation.
