### PR TITLE
Avoid unwanted NuGet PRs

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -75,7 +75,7 @@
       "description": ["Skip pinned NuGet package versions"],
       "matchManagers": ["nuget"],
       "matchCurrentValue": "^\\[[^,]+,\\)$",
-      "matchNewValue": "^\\[[^,]+,\\)$",
+      "rangeStrategy": "auto",
       "enabled": false
     },
     {


### PR DESCRIPTION
Another attempt at fixing renovate to not generate PRs for pinned NuGet dependencies after changes in #185.
