### PR TITLE
Revert NuGet configuration changes

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -75,13 +75,7 @@
       "description": ["Skip pinned NuGet package versions"],
       "matchManagers": ["nuget"],
       "matchCurrentValue": "^\\[[^,]+,\\)$",
-      "rangeStrategy": "auto",
       "enabled": false
-    },
-    {
-      "description": ["Workaround for https://github.com/renovatebot/renovate/discussions/43794"],
-      "matchManagers": ["nuget"],
-      "rangeStrategy": "bump"
     },
     {
       "extends": ["monorepo:opentelemetry-dotnet", "monorepo:opentelemetry-dotnet-contrib"],


### PR DESCRIPTION
Revert #185 and subsequent updates as renovate keeps generating PRs to update pinned dependencies.
