### PR TITLE
Attempt to fix renovate updates again

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -72,9 +72,15 @@
       "addLabels": [".NET"]
     },
     {
-      "description": ["Skip pinned NuGet package versions"],
+      "description": ["Workaround for https://github.com/renovatebot/renovate/discussions/43794"],
       "matchManagers": ["nuget"],
-      "matchCurrentValue": "^\\[[^,]+,\\)$",
+      "matchCurrentValue": "^[^\\[(]",
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": ["Skip NuGet package versions with explicit version ranges"],
+      "matchManagers": ["nuget"],
+      "matchCurrentValue": "^[\\[(]",
       "enabled": false
     },
     {


### PR DESCRIPTION
Apply Claude-suggested changes to attempt to still get NuGet updates without receiving them for pinned NuGet packages.
