### PR TITLE
Attempt to fix renovate updates again

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -77,7 +77,7 @@
       "rangeStrategy": "bump"
     },
     {
-      "description": ["Skip NuGet package versions with explicit version ranges"],
+      "description": ["Skip pinned NuGet package versions"],
       "matchManagers": ["nuget"],
       "matchCurrentValue": "^\\[[^,]+,\\)$",
       "rangeStrategy": "widen"

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -74,14 +74,13 @@
     {
       "description": ["Workaround for https://github.com/renovatebot/renovate/discussions/43794"],
       "matchManagers": ["nuget"],
-      "matchCurrentValue": "^[^\\[(]",
       "rangeStrategy": "bump"
     },
     {
       "description": ["Skip NuGet package versions with explicit version ranges"],
       "matchManagers": ["nuget"],
-      "matchCurrentValue": "^[\\[(]",
-      "enabled": false
+      "matchCurrentValue": "^\\[[^,]+,\\)$",
+      "rangeStrategy": "widen"
     },
     {
       "extends": ["monorepo:opentelemetry-dotnet", "monorepo:opentelemetry-dotnet-contrib"],


### PR DESCRIPTION
Apply Claude-suggested changes to attempt to still get NuGet updates without receiving them for pinned NuGet packages.
