### PR TITLE
Attempt to fix renovate updates again

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -72,9 +72,14 @@
       "addLabels": [".NET"]
     },
     {
+      "description": ["Workaround for https://github.com/renovatebot/renovate/discussions/43794"],
+      "matchManagers": ["nuget"],
+      "rangeStrategy": "bump"
+    },
+    {
       "description": ["Skip pinned NuGet package versions"],
       "matchManagers": ["nuget"],
-      "matchCurrentValue": "^\\[[^,]+,\\)$",
+      "matchNewValue": "^\\[[^,]+,\\)$",
       "enabled": false
     },
     {


### PR DESCRIPTION
Apply Claude-suggested changes to attempt to still get NuGet updates without receiving them for pinned NuGet packages.
